### PR TITLE
APIKIT-1880: apikit.exception.NotAcceptableException: Not Acceptable when using charset in OAS response types

### DIFF
--- a/src/main/java/org/mule/module/apikit/api/validation/RequestValidator.java
+++ b/src/main/java/org/mule/module/apikit/api/validation/RequestValidator.java
@@ -86,7 +86,7 @@ public class RequestValidator {
 
       final String method = attributes.getMethod().toLowerCase();
       if (resource.getAction(method) == null) {
-        final String version = resolvedVariables.get("version").toString();
+        final String version = (String) resolvedVariables.get("version");
         throw new MethodNotAllowedException(resource.getResolvedUri(version) + " : " + method);
       }
 

--- a/src/main/java/org/mule/module/apikit/validation/attributes/HeadersValidator.java
+++ b/src/main/java/org/mule/module/apikit/validation/attributes/HeadersValidator.java
@@ -144,13 +144,6 @@ public class HeadersValidator {
       throw new NotAcceptableException();
     }
     logger.debug("=== negotiated response content-type: " + bestMatch.toString());
-    for (String representation : mimeTypes) {
-      if (representation.equals(bestMatch.withoutParameters().toString())) {
-        //there is a valid representation
-        return;
-      }
-    }
-    throw new NotAcceptableException();
   }
 
   private List<String> getResponseMimeTypes(IAction action) {

--- a/src/test/munit/api-routing/api-routing-test-suite.xml
+++ b/src/test/munit/api-routing/api-routing-test-suite.xml
@@ -20,7 +20,7 @@
     <munit:execution>
       <http:request method="PUT" config-ref="http-request-config-localhost-8081" path="/api/apply-with-charset">
         <http:body >#[output application/json ---{"effectiveDate": "2006-03-03"}]</http:body>
-        <http:headers >#[output application/java --- { "Content-Type" : "application/json; charset=utf-8"}]</http:headers>
+        <http:headers>#[output application/java --- { "Content-Type" : "application/json; charset=utf-8", "accept" : "application/json; charset=utf-8" }]</http:headers>
       </http:request>
     </munit:execution>
     <munit:validation>

--- a/src/test/resources/munit/api-routing.raml
+++ b/src/test/resources/munit/api-routing.raml
@@ -17,7 +17,7 @@ types:
     responses:
       200:
         body:
-            application/json:
+            application/json; charset=utf-8:
               type: ApplyCreditMemoType
     body:
       application/json; charset=utf-8:


### PR DESCRIPTION
…when using charset in OAS response types