### PR TITLE
APIKIT-2678: No enum constant org.mule.apikit.model.ActionType.LINK instead of method not allowed

### DIFF
--- a/src/main/java/org/mule/module/apikit/api/validation/RequestValidator.java
+++ b/src/main/java/org/mule/module/apikit/api/validation/RequestValidator.java
@@ -15,11 +15,14 @@ import org.mule.module.apikit.api.exception.MethodNotAllowedException;
 import org.mule.module.apikit.api.exception.MuleRestException;
 import org.mule.module.apikit.api.uri.ResolvedVariables;
 import org.mule.apikit.model.Resource;
+import org.mule.module.apikit.validation.HttpMethodValidator;
 import org.mule.module.apikit.validation.RestRequestValidator;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
 import org.mule.runtime.api.exception.MuleRuntimeException;
 
 public class RequestValidator {
+
+  private static final HttpMethodValidator methodValidator = new HttpMethodValidator();
 
   private RequestValidator() {}
 
@@ -41,6 +44,7 @@ public class RequestValidator {
                                      createStaticMessage("Unexpected error. Resource cannot be null"));
     }
     String method = attributes.getMethod().toLowerCase();
+    methodValidator.validateHttpMethod(method);
     Action action = resource.getAction(method);
     if (action == null) {
       throw new MethodNotAllowedException(resource.getResolvedUri((String) resolvedVariables.get("version")) + " : " + method);

--- a/src/main/java/org/mule/module/apikit/validation/HttpMethodValidator.java
+++ b/src/main/java/org/mule/module/apikit/validation/HttpMethodValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) MuleSoft, Inc.  All rights reserved.  http://www.mulesoft.com
+ * The software in this package is published under the terms of the CPAL v1.0
+ * license, a copy of which has been included with this distribution in the
+ * LICENSE.txt file.
+ */
+package org.mule.module.apikit.validation;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.Set;
+import org.mule.apikit.model.ActionType;
+import org.mule.module.apikit.api.exception.MethodNotAllowedException;
+
+public class HttpMethodValidator {
+
+  /**
+   * RAML : methods defined in the HTTP version 1.1 specification RFC2616 and its extension, RFC5789
+   * OAS : https://tools.ietf.org/html/rfc7231#section-4.3.1
+   */
+  private static final Set<String> httpValidMethods = asList(ActionType.values())
+      .stream()
+      .map(value -> value.toString().toLowerCase())
+      .collect(toSet());
+
+
+  /**
+   * @param requestMethod HTTP method in lower case
+   * @throws MethodNotAllowedException
+   */
+  public void validateHttpMethod(String requestMethod) throws MethodNotAllowedException {
+    if (!httpValidMethods.contains(requestMethod)) {
+      throw new MethodNotAllowedException(String.format("HTTP Method : %s is not allowed", requestMethod));
+    }
+  }
+
+}

--- a/src/test/munit/error/default-error-handler-test-case.xml
+++ b/src/test/munit/error/default-error-handler-test-case.xml
@@ -81,6 +81,26 @@
         </munit:validation>
     </munit:test>
 
+    <munit:test name="throw-405-when-HTTP-method-not-allowed-in-raml-oas-spec">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="default-error-handler-main"/>
+            <munit:enable-flow-source value="get:\raiseError:default-error-handler-config"/>
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <http:request method="COPY" config-ref="http-requester-simple" path="/error-handler/raiseError">
+                <http:response-validator>
+                    <http:success-status-code-validator values="1..500"/>
+                </http:response-validator>
+            </http:request>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(405)]"/>
+            <munit-tools:assert-that expression="#[attributes.headers.'Content-Type']"
+              is="#[MunitTools::equalTo('application/json')]"/>
+            <munit-tools:assert-that expression="#[payload.message]" is="#[MunitTools::equalTo('Method not allowed')]"/>
+        </munit:validation>
+    </munit:test>
+
     <munit:test name="throw415">
         <munit:enable-flow-sources>
             <munit:enable-flow-source value="default-error-handler-main"/>


### PR DESCRIPTION
…nstead of method not allowed