### PR TITLE
APIKIT-2805: ApiKit not accepting Colons (:) in URL path (#330)

### DIFF
--- a/src/main/java/org/mule/module/apikit/FlowFinder.java
+++ b/src/main/java/org/mule/module/apikit/FlowFinder.java
@@ -6,18 +6,9 @@
  */
 package org.mule.module.apikit;
 
-import static java.lang.String.format;
-import static org.mule.module.apikit.ApikitErrorTypes.throwErrorType;
-import static org.mule.module.apikit.api.FlowUtils.getFlowsList;
-import static org.mule.module.apikit.helpers.AttributesHelper.getMediaType;
-import static org.mule.module.apikit.helpers.FlowName.FLOW_NAME_SEPARATOR;
-import static org.mule.module.apikit.helpers.FlowName.URL_RESOURCE_SEPARATOR;
-
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.mule.apikit.model.Action;
+import org.mule.apikit.model.ApiSpecification;
+import org.mule.apikit.model.Resource;
 import org.mule.module.apikit.api.RamlHandler;
 import org.mule.module.apikit.api.RoutingTable;
 import org.mule.module.apikit.api.uri.URIPattern;
@@ -25,14 +16,24 @@ import org.mule.module.apikit.api.uri.URIResolver;
 import org.mule.module.apikit.exception.NotImplementedException;
 import org.mule.module.apikit.exception.UnsupportedMediaTypeException;
 import org.mule.module.apikit.helpers.FlowName;
-import org.mule.apikit.model.Action;
-import org.mule.apikit.model.ApiSpecification;
-import org.mule.apikit.model.Resource;
+import org.mule.module.apikit.uri.URICoder;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
 import org.mule.runtime.api.exception.ErrorTypeRepository;
 import org.mule.runtime.core.api.construct.Flow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.String.format;
+import static org.mule.module.apikit.ApikitErrorTypes.throwErrorType;
+import static org.mule.module.apikit.api.FlowUtils.getFlowsList;
+import static org.mule.module.apikit.helpers.AttributesHelper.getMediaType;
+import static org.mule.module.apikit.helpers.FlowName.FLOW_NAME_SEPARATOR;
+import static org.mule.module.apikit.helpers.FlowName.URL_RESOURCE_SEPARATOR;
 
 
 public class FlowFinder {
@@ -153,7 +154,7 @@ public class FlowFinder {
 
   private String validateRestFlowKeyAgainstApi(String... coords) {
     String method = coords[0];
-    String resource = coords[1];
+    String resource = URICoder.decode(coords[1]);
     String type = coords.length == 3 ? coords[2] : null;
     String key = format("%s:%s", method, resource);
 

--- a/src/main/java/org/mule/module/apikit/uri/URICoder.java
+++ b/src/main/java/org/mule/module/apikit/uri/URICoder.java
@@ -7,6 +7,8 @@
 
 package org.mule.module.apikit.uri;
 
+import org.mule.module.apikit.api.exception.ApikitRuntimeException;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.text.Normalizer;
@@ -14,7 +16,6 @@ import java.text.Normalizer.Form;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import org.mule.module.apikit.api.exception.ApikitRuntimeException;
 
 /**
  * An encoder/decoder for use by URI templates.
@@ -57,9 +58,9 @@ public class URICoder {
   private final static int ENCODE_INITIAL_CAPACITY = 16;
 
   /**
-   *  Reserved chars, not considered when detecting bad encoding
+   * Reserved chars, not considered when detecting bad encoding
    */
-  private final static Set<Character> skipChars = new HashSet<>(Arrays.asList('/', '{', '}', '%'));
+  private final static Set<Character> skipChars = new HashSet<>(Arrays.asList('/', '{', '}', '%', ':'));
 
   /**
    *  Reserved chars, not considered when encoding request path

--- a/src/main/java/org/mule/module/apikit/uri/Variable.java
+++ b/src/main/java/org/mule/module/apikit/uri/Variable.java
@@ -88,8 +88,6 @@ public class Variable {
     }
   }
 
-  ;
-
   /**
    * Indicate that the variable's value should be processed as a list ("@") or an associative array ("%").
    * <p/>
@@ -148,7 +146,7 @@ public class Variable {
    * sequence. This pattern contains non-capturing parentheses to make it easier to get variable
    * values as a group.
    */
-  protected static final Pattern VALID_VALUE = Pattern.compile("[\\w.~%-]+");
+  protected static final Pattern VALID_VALUE = Pattern.compile("[\\w.~%-:]+");
 
   /**
    * The default value is an empty string.

--- a/src/test/java/org/mule/module/apikit/uri/URICoderTestCase.java
+++ b/src/test/java/org/mule/module/apikit/uri/URICoderTestCase.java
@@ -6,12 +6,12 @@
  */
 package org.mule.module.apikit.uri;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsEqual.equalTo;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 
 public class URICoderTestCase {
 
@@ -20,8 +20,8 @@ public class URICoderTestCase {
 
   @Test
   public void encodeCorrectEncodedURI() {
-    assertThat(URICoder.encodeRequestPath("api/uri-param/AA%2F11%2F00000070/test"),
-               equalTo("api/uri-param/AA%2F11%2F00000070/test"));
+    assertThat(URICoder.encodeRequestPath("api/uri-param/AA%2F11%2F000000%2A70/test"),
+               equalTo("api/uri-param/AA%2F11%2F000000%2A70/test"));
   }
 
   @Test
@@ -31,9 +31,21 @@ public class URICoderTestCase {
   }
 
   @Test
-  public void halfEncoding() {
+  public void halfEncodingIsIncorrect() {
     expectedException.expectMessage("Request path contains special characters not encoded");
-    URICoder.encodeRequestPath("api/uri-param/AA:11%2070/test");
+    URICoder.encodeRequestPath("api/uri-param/AA11%20*70/test");
+  }
+
+  @Test
+  public void colonInEncodedIsCorrect() {
+    assertThat(URICoder.encodeRequestPath("api/uri-param/AA:11%2070/test"),
+               equalTo("api/uri-param/AA:11%2070/test"));
+  }
+
+  @Test
+  public void encodedColonIsCorrect() {
+    assertThat(URICoder.encodeRequestPath("api/uri-param/AA%3A11%2070/test"),
+               equalTo("api/uri-param/AA%3A11%2070/test"));
   }
 
   @Test

--- a/src/test/munit/flow-routing/flow-routing-server.xml
+++ b/src/test/munit/flow-routing/flow-routing-server.xml
@@ -12,12 +12,6 @@
                  httpStatusVarName="httpStatus" parser="${parser.type}">
     <apikit:flow-mappings>
       <apikit:flow-mapping resource="/mapping" action="get" flow-ref="test-flow-mapping"/>
-
-      <!-- TODO: THIS ONES SHOULD BE REMOVED, SHOULD BE WAD -->
-      <apikit:flow-mapping resource="/apply-with-charset" action="put" content-type="application/json" flow-ref="put:\apply-with-charset:application\json:api-routing-config" />
-      <apikit:flow-mapping resource="/{resourceType}:{id}" action="get" flow-ref="get:\(resourceType):(id):api-routing-config" />
-      <apikit:flow-mapping resource="/uri-param/{uriID}/test" action="get" flow-ref="get:\uri-param\(uriID)\test:api-routing-config"/>
-
     </apikit:flow-mappings>
   </apikit:config>
 
@@ -39,7 +33,7 @@
     <logger level="INFO" message="put:\apply-with-charset:application\json:api-routing-config"/>
   </flow>
 
-  <flow name="get:\(resourceType):(id):api-routing-config">
+  <flow name="get:\(resourceType)%3A(id):api-routing-config">
     <set-payload value="#[output application/json --- {&quot;name&quot;: &quot;testType&quot;}]"/>
   </flow>
 

--- a/src/test/munit/flow-routing/flow-routing-test-suite.xml
+++ b/src/test/munit/flow-routing/flow-routing-test-suite.xml
@@ -53,7 +53,7 @@
   <munit:test name="api-with-colons-routing-encoded-test">
     <munit:enable-flow-sources>
       <munit:enable-flow-source value="api-routing-main"/>
-      <munit:enable-flow-source value="get:\(resourceType):(id):api-routing-config"/>
+      <munit:enable-flow-source value="get:\(resourceType)%3A(id):api-routing-config"/>
     </munit:enable-flow-sources>
     <munit:execution>
       <http:request method="GET" config-ref="http-requester-simple"
@@ -68,15 +68,15 @@
   <munit:test name="api-with-colons-routing-not-encoded-test">
     <munit:enable-flow-sources>
       <munit:enable-flow-source value="api-routing-main"/>
-      <munit:enable-flow-source value="get:\(resourceType):(id):api-routing-config"/>
+      <munit:enable-flow-source value="get:\(resourceType)%3A(id):api-routing-config"/>
     </munit:enable-flow-sources>
     <munit:execution>
       <http:request method="GET" config-ref="http-requester-simple"
-        path="/api/test:100" target="notEncoded"/>
+                    path="/api/test:100" target="notEncoded"/>
     </munit:execution>
     <munit:validation>
       <munit-tools:assert-that expression="#[vars.notEncoded.name]"
-        is="#[MunitTools::equalTo('testType')]"/>
+                               is="#[MunitTools::equalTo('testType')]"/>
     </munit:validation>
   </munit:test>
 
@@ -87,7 +87,7 @@
     </munit:enable-flow-sources>
     <munit:execution>
       <http:request method="GET" config-ref="http-requester-simple"
-        path="api/uri-param/AA%252F11%252F00000070/test"/>
+                    path="api/uri-param/AA%252F11%252F00000070/test"/>
     </munit:execution>
     <munit:validation>
       <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(200)]"/>
@@ -102,11 +102,47 @@
     </munit:enable-flow-sources>
     <munit:execution>
       <http:request method="GET" config-ref="http-requester-simple"
-        path="api/uri-param/AA%2F11%2F00000070/test"/>
+                    path="api/uri-param/AA%2F11%2F00000070/test"/>
     </munit:execution>
     <munit:validation>
       <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(200)]"/>
       <munit-tools:assert-that expression="#[payload.test]" is="#[MunitTools::equalTo('AA/11/00000070')]"/>
+    </munit:validation>
+  </munit:test>
+
+  <munit:test name="uri-param-with-non-encoded-colon">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source value="api-routing-main"/>
+      <munit:enable-flow-source value="get:\uri-param\(uriID)\test:api-routing-config"/>
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request method="GET" config-ref="http-requester-simple" path="api/uri-param/AA%2011:00000070/test">
+        <http:response-validator>
+          <http:success-status-code-validator values="1..501"/>
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(200)]"/>
+      <munit-tools:assert-that expression="#[payload.test]" is="#[MunitTools::equalTo('AA 11:00000070')]"/>
+    </munit:validation>
+  </munit:test>
+
+  <munit:test name="uri-param-with-encoded-colon">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source value="api-routing-main"/>
+      <munit:enable-flow-source value="get:\uri-param\(uriID)\test:api-routing-config"/>
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request method="GET" config-ref="http-requester-simple" path="api/uri-param/AA%2011%3A00000070/test">
+        <http:response-validator>
+          <http:success-status-code-validator values="1..501"/>
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(200)]"/>
+      <munit-tools:assert-that expression="#[payload.test]" is="#[MunitTools::equalTo('AA 11:00000070')]"/>
     </munit:validation>
   </munit:test>
 
@@ -116,7 +152,7 @@
       <munit:enable-flow-source value="get:\uri-param\(uriID)\test:api-routing-config"/>
     </munit:enable-flow-sources>
     <munit:execution>
-      <http:request method="GET" config-ref="http-requester-simple" path="api/uri-param/AA%2011:00000070/test">
+      <http:request method="GET" config-ref="http-requester-simple" path="api/uri-param/AA%2011:000000*70/test">
         <http:response-validator>
           <http:success-status-code-validator values="1..501"/>
         </http:response-validator>
@@ -181,4 +217,5 @@
       <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(415)]"/>
     </munit:validation>
   </munit:test>
+
 </mule>


### PR DESCRIPTION
* APIKIT-2805: APIKit router fails when both space(%20) and Colon(:) value exist in URI param

* APIKIT-2805: ApiKit not accepting Colons (:) in URL path