### PR TITLE
APIKIT-2822: Revert packages refactoring and update API to include boolean instead (#347)

### DIFF
--- a/src/main/resources/META-INF/mule-artifact/mule-artifact.json
+++ b/src/main/resources/META-INF/mule-artifact/mule-artifact.json
@@ -27,8 +27,7 @@
         "org.mule.module.apikit.api.deserializing",
         "org.mule.module.apikit.spi",
         "org.mule.apikit.model",
-        "org.mule.parser.service",
-        "org.mule.parser.service.result"
+        "org.mule.parser.service"
       ],
       "exportedResources": [
         "/META-INF/",


### PR DESCRIPTION
* Revert "APIKIT-2821: Move ParserService to internal package (#345)"

This reverts commit cda039fc042ae8772347f16f28f61b312f970175.

* Revert "APIKIT-2821: Export parser service result package (#341)"

This reverts commit 37a32d8f4ac975d4639130d7ea26bfdbce49837a.

* APIKIT-2822: Revert packages refactoring and update API to include boolean instead