### PR TITLE
W-12586382: Fail empy URI params at resolution time (instead of match time)

### DIFF
--- a/src/main/java/org/mule/module/apikit/Router.java
+++ b/src/main/java/org/mule/module/apikit/Router.java
@@ -28,6 +28,7 @@ import org.mule.module.apikit.routing.DefaultFlowRoutingStrategy;
 import org.mule.module.apikit.routing.FlowRoutingStrategy;
 import org.mule.module.apikit.routing.PrivilegedFlowRoutingStrategy;
 import org.mule.module.apikit.uri.URICoder;
+import org.mule.module.apikit.uri.URIResolveResult;
 import org.mule.module.apikit.utils.MuleVersionUtils;
 import org.mule.runtime.api.component.AbstractComponent;
 import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
@@ -157,7 +158,12 @@ public class Router extends AbstractComponent implements Processor, Initialisabl
     // Get uriPattern, uriResolver, and the resolvedVariables
     URIPattern uriPattern = findInCache(path, config.getUriPatternCache());
     URIResolver uriResolver = findInCache(path, config.getUriResolverCache());
-    ResolvedVariables resolvedVariables = uriResolver.resolve(uriPattern);
+    URIResolveResult resolvedVariables = uriResolver.resolve(uriPattern);
+
+    if (URIResolveResult.Status.ERROR.equals(resolvedVariables.getStatus())) {
+      throw new InvalidUriParameterException("Unable to resolve valid URI parameter values for the requested URL");
+    }
+
     Resource resource = config.getFlowFinder().getResource(uriPattern);
 
     TypedValue<Object> payload = mainEvent.getMessage().getPayload();

--- a/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
+++ b/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
@@ -159,7 +159,11 @@ public class URIResolver {
     for (int i = 0; i < mx.groupCount(); i++) {
       Token mt = tokens.get(i);
       String s = mx.group(i + 1);
-      mt.resolve(s, map);
+      boolean wasSuccessful = mt.resolve(s, map);
+      if (!wasSuccessful) {
+        result.setStatus(ERROR);
+        return result;
+      }
     }
     // lookup variable values
     lookup(result, map);

--- a/src/main/java/org/mule/module/apikit/uri/TokenVariable.java
+++ b/src/main/java/org/mule/module/apikit/uri/TokenVariable.java
@@ -70,6 +70,9 @@ public class TokenVariable extends TokenBase implements Token, Matchable {
    * {@inheritDoc}
    */
   public boolean resolve(String expanded, Map<Variable, Object> values) {
+    if (expanded.isEmpty()) {
+      return false;
+    }
     values.put(this._var, URICoder.decode(expanded));
     return true;
   }

--- a/src/main/java/org/mule/module/apikit/uri/Variable.java
+++ b/src/main/java/org/mule/module/apikit/uri/Variable.java
@@ -145,7 +145,7 @@ public class Variable {
    * The pattern for a valid normalised variable value: any unreserved character or an escape sequence. This pattern contains
    * non-capturing parentheses to make it easier to get variable values as a group.
    */
-  protected static final Pattern VALID_VALUE = Pattern.compile("[\\w.~%:-]+");
+  protected static final Pattern VALID_VALUE = Pattern.compile("[\\w.~%:-]*");
 
   /**
    * The default value is an empty string.

--- a/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
+++ b/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
@@ -18,6 +18,8 @@ import org.junit.Test;
 import org.mule.module.apikit.api.RamlHandler;
 import org.mule.module.apikit.api.RoutingTable;
 import org.mule.module.apikit.api.uri.URIPattern;
+import org.mule.module.apikit.api.uri.URIResolver;
+import org.mule.module.apikit.uri.URIResolveResult;
 import org.mule.runtime.core.api.MuleContext;
 
 public class RoutingTableTestCase {
@@ -42,6 +44,14 @@ public class RoutingTableTestCase {
                                                       new URIPattern("/api"),
                                                       new URIPattern("/api/sub-resource"),
                                                       new URIPattern("/api/sub-resource-types")));
+  }
+
+  @Test
+  public void emptyParametersAreMatchedButNotResolved() {
+    URIPattern pattern = new URIPattern("/api/{parameter}/list");
+    Assert.assertTrue(pattern.match("/api//list"));
+    URIResolver resolver = new URIResolver("/api//list");
+    Assert.assertEquals(URIResolveResult.Status.ERROR, resolver.resolve(pattern).getStatus());
   }
 
   @Test

--- a/src/test/munit/flow-routing/flow-routing-test-suite.xml
+++ b/src/test/munit/flow-routing/flow-routing-test-suite.xml
@@ -179,6 +179,22 @@
     </munit:validation>
   </munit:test>
 
+  <munit:test name="resource-empty-variable-does-not-match">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source value="api-routing-main"/>
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request method="POST" config-ref="http-requester-simple" path="api/customers//applications/1A84dsfsf4fg">
+        <http:response-validator>
+          <http:success-status-code-validator values="1..501"/>
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(400)]"/>
+    </munit:validation>
+  </munit:test>
+
   <munit:test name="perform-request-that-uses-a-flow-mapping">
     <munit:enable-flow-sources>
       <munit:enable-flow-source value="api-routing-main"/>


### PR DESCRIPTION
This provides a better error message (either we try validation and fail against `null` or we use a custom error message) and a better status code (400 instead of 404).