### PR TITLE
W-15162242: MimeType compatibility requires both type and subtype to be compatible

### DIFF
--- a/src/main/java/org/mule/module/apikit/validation/attributes/HeadersValidator.java
+++ b/src/main/java/org/mule/module/apikit/validation/attributes/HeadersValidator.java
@@ -233,7 +233,7 @@ public class HeadersValidator {
   }
 
   private static boolean isCompatible(MimeType expected, MimeType supported) {
-    return isCompatible(expected.getType(), supported.getType()) && isCompatible(expected.getType(), supported.getType());
+    return isCompatible(expected.getType(), supported.getType()) && isCompatible(expected.getSubtype(), supported.getSubtype());
   }
 
   private static boolean isCompatible(String expected, String supported) {


### PR DESCRIPTION
This was triggered by W-15161908. I'm a bit ashamed I didn't catch that.