### PR TITLE
W-14747249 :  Match URI patterns with trailing slashes correctly

### DIFF
--- a/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
+++ b/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
@@ -226,12 +226,23 @@ public class URIResolver {
     URIPattern best = null;
     for (URIPattern p : patterns) {
       if (p.match(this._uri)) {
-        if (best == null || p.score() > best.score()) {
-          best = p;
+        if (hasTrailingForwardSlash(p)) {
+          if (best == null || p.score() > best.score()) {
+            best = p;
+          }
         }
       }
     }
     return best;
+  }
+
+  private boolean hasTrailingForwardSlash(URIPattern p) {
+
+    if (this._uri.endsWith("/")) {
+      return p.toString().endsWith("/");
+    } else {
+      return true;
+    }
   }
 
 }

--- a/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
+++ b/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
@@ -225,24 +225,13 @@ public class URIResolver {
     }
     URIPattern best = null;
     for (URIPattern p : patterns) {
-      if (p.match(this._uri)) {
-        if (hasTrailingForwardSlash(p)) {
-          if (best == null || p.score() > best.score()) {
-            best = p;
-          }
+      if (p.match(this._uri) && (!this._uri.endsWith("/") || p.toString().endsWith("/"))) {
+        if (best == null || p.score() > best.score()) {
+          best = p;
         }
       }
     }
     return best;
-  }
-
-  private boolean hasTrailingForwardSlash(URIPattern p) {
-
-    if (this._uri.endsWith("/")) {
-      return p.toString().endsWith("/");
-    } else {
-      return true;
-    }
   }
 
 }

--- a/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
+++ b/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
@@ -100,6 +100,7 @@ public class RoutingTableTestCase {
     patterns.add(new URIPattern("/api/hello/{param}"));
     patterns.add(new URIPattern("/api/hello/{param}/all"));
     patterns.add(new URIPattern("/api/hello"));
+    patterns.add(new URIPattern("/api/"));
 
     URIResolver resolver1 = new URIResolver("/api/hello/");
     Assert.assertNull(resolver1.find(patterns, URIResolver.MatchRule.BEST_MATCH));

--- a/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
+++ b/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
@@ -60,31 +60,38 @@ public class RoutingTableTestCase {
     URIPattern pattern1 = new URIPattern("/api/hello/");
     URIPattern pattern2 = new URIPattern("/");
     URIPattern pattern3 = new URIPattern("/{param}");
+    URIPattern pattern4 = new URIPattern("/api/hello/{param}");
+    URIPattern pattern5 = new URIPattern("/api/hello/{param}/all");
+    URIPattern pattern6 = new URIPattern("/api/hello");
+    URIPattern pattern7 = new URIPattern("/{param}/");
     HashSet<URIPattern> patterns = new HashSet<>();
     patterns.add(pattern1);
     patterns.add(pattern2);
     patterns.add(pattern3);
-    patterns.add(new URIPattern("/api/hello/{param}"));
-    patterns.add(new URIPattern("/api/hello/{param}/all"));
-    patterns.add(new URIPattern("/api/hello"));
+    patterns.add(pattern4);
+    patterns.add(pattern5);
+    patterns.add(pattern6);
+    patterns.add(pattern7);
 
     URIResolver resolver1 = new URIResolver("/api/hello/");
     URIPattern bestPattern1 = resolver1.find(patterns, URIResolver.MatchRule.BEST_MATCH);
-
     Assert.assertEquals(URIResolveResult.Status.RESOLVED, resolver1.resolve(bestPattern1).getStatus());
     Assert.assertEquals(pattern1, bestPattern1);
 
     URIResolver resolver2 = new URIResolver("/");
     URIPattern bestPattern2 = resolver2.find(patterns, URIResolver.MatchRule.BEST_MATCH);
-
     Assert.assertEquals(URIResolveResult.Status.RESOLVED, resolver2.resolve(bestPattern2).getStatus());
     Assert.assertEquals(pattern2, bestPattern2);
 
     URIResolver resolver3 = new URIResolver("/api");
     URIPattern bestPattern3 = resolver3.find(patterns, URIResolver.MatchRule.BEST_MATCH);
-
     Assert.assertEquals(URIResolveResult.Status.RESOLVED, resolver3.resolve(bestPattern3).getStatus());
     Assert.assertEquals(pattern3, bestPattern3);
+
+    URIResolver resolver7 = new URIResolver("/api/");
+    URIPattern bestPattern7 = resolver7.find(patterns, URIResolver.MatchRule.BEST_MATCH);
+    Assert.assertEquals(URIResolveResult.Status.RESOLVED, resolver7.resolve(bestPattern7).getStatus());
+    Assert.assertEquals(pattern7, bestPattern7);
   }
 
   @Test

--- a/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
+++ b/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
@@ -10,6 +10,7 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.HashSet;
 
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -52,6 +53,56 @@ public class RoutingTableTestCase {
     Assert.assertTrue(pattern.match("/api//list"));
     URIResolver resolver = new URIResolver("/api//list");
     Assert.assertEquals(URIResolveResult.Status.ERROR, resolver.resolve(pattern).getStatus());
+  }
+
+  @Test
+  public void URIWithTrailingForwardSlashAreMatchedAndResolvedCorrectly() {
+    URIPattern pattern1 = new URIPattern("/api/hello/");
+    URIPattern pattern2 = new URIPattern("/");
+    URIPattern pattern3 = new URIPattern("/{param}");
+    HashSet<URIPattern> patterns = new HashSet<>();
+    patterns.add(pattern1);
+    patterns.add(pattern2);
+    patterns.add(pattern3);
+    patterns.add(new URIPattern("/api/hello/{param}"));
+    patterns.add(new URIPattern("/api/hello/{param}/all"));
+    patterns.add(new URIPattern("/api/hello"));
+
+    URIResolver resolver1 = new URIResolver("/api/hello/");
+    URIPattern bestPattern1 = resolver1.find(patterns, URIResolver.MatchRule.BEST_MATCH);
+
+    Assert.assertEquals(URIResolveResult.Status.RESOLVED, resolver1.resolve(bestPattern1).getStatus());
+    Assert.assertEquals(pattern1, bestPattern1);
+
+    URIResolver resolver2 = new URIResolver("/");
+    URIPattern bestPattern2 = resolver2.find(patterns, URIResolver.MatchRule.BEST_MATCH);
+
+    Assert.assertEquals(URIResolveResult.Status.RESOLVED, resolver2.resolve(bestPattern2).getStatus());
+    Assert.assertEquals(pattern2, bestPattern2);
+
+    URIResolver resolver3 = new URIResolver("/api");
+    URIPattern bestPattern3 = resolver3.find(patterns, URIResolver.MatchRule.BEST_MATCH);
+
+    Assert.assertEquals(URIResolveResult.Status.RESOLVED, resolver3.resolve(bestPattern3).getStatus());
+    Assert.assertEquals(pattern3, bestPattern3);
+  }
+
+  @Test
+  public void URIWithTrailingForwardSlashAreNotMatched() {
+    HashSet<URIPattern> patterns = new HashSet<>();
+    patterns.add(new URIPattern("/api/hello/{param}"));
+    patterns.add(new URIPattern("/api/hello/{param}/all"));
+    patterns.add(new URIPattern("/api/hello"));
+
+    URIResolver resolver1 = new URIResolver("/api/hello/");
+    Assert.assertNull(resolver1.find(patterns, URIResolver.MatchRule.BEST_MATCH));
+
+    URIResolver resolver3 = new URIResolver("/api");
+    Assert.assertNull(resolver3.find(patterns, URIResolver.MatchRule.BEST_MATCH));
+
+    patterns.add(new URIPattern("/{param}"));
+    URIResolver resolver2 = new URIResolver("/");
+    Assert.assertNull(resolver2.find(patterns, URIResolver.MatchRule.BEST_MATCH));
   }
 
   @Test

--- a/src/test/munit/flow-routing/flow-routing-test-suite.xml
+++ b/src/test/munit/flow-routing/flow-routing-test-suite.xml
@@ -195,6 +195,22 @@
     </munit:validation>
   </munit:test>
 
+  <munit:test name="resource-trailing-slash-does-not-match">
+    <munit:enable-flow-sources>
+      <munit:enable-flow-source value="api-routing-main"/>
+    </munit:enable-flow-sources>
+    <munit:execution>
+      <http:request method="POST" config-ref="http-requester-simple" path="api/customers/3123/applications/">
+        <http:response-validator>
+          <http:success-status-code-validator values="1..501"/>
+        </http:response-validator>
+      </http:request>
+    </munit:execution>
+    <munit:validation>
+      <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(404)]"/>
+    </munit:validation>
+  </munit:test>
+
   <munit:test name="perform-request-that-uses-a-flow-mapping">
     <munit:enable-flow-sources>
       <munit:enable-flow-source value="api-routing-main"/>


### PR DESCRIPTION
Mapping of resources with matching request path is determined by the order of resources returned by Routing Table

`/path1/{param}` and `/path1/` get matched to same pattern depending on the order of patterns (keySet of Routing Table which is a HashMap). To handle this edge case, we are adding conditions to check if the received URI has a trailing slash

WI: [W-14747249](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001hQs7OYAS/view)