### PR TITLE
W-16328046 : set lowercase in header name with type array in RAML

### DIFF
--- a/src/main/java/org/mule/module/apikit/validation/attributes/HeadersValidator.java
+++ b/src/main/java/org/mule/module/apikit/validation/attributes/HeadersValidator.java
@@ -96,7 +96,7 @@ public class HeadersValidator {
           copyIncomingHeaders.removeAll(headerName.toLowerCase());
           copyIncomingHeaders.removeAll(headerName);
           // Putting back header name with same case as there is in spec (headers are case-insensitive)
-          copyIncomingHeaders.put(headerName, values);
+          copyIncomingHeaders.put(headerName.toLowerCase(), values);
         }
         validateHeader(values, headerName, headerType);
       }

--- a/src/test/java/org/mule/module/apikit/validation/HeaderParamsRequestValidator.java
+++ b/src/test/java/org/mule/module/apikit/validation/HeaderParamsRequestValidator.java
@@ -7,7 +7,11 @@
 package org.mule.module.apikit.validation;
 
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.mule.module.apikit.api.exception.MuleRestException;
+import org.mule.module.apikit.api.validation.ValidRequest;
 import org.mule.module.apikit.exception.NotAcceptableException;
 import org.mule.runtime.api.util.MultiMap;
 
@@ -66,5 +70,33 @@ public class HeaderParamsRequestValidator extends AbstractRequestValidatorTestCa
   @Test
   public void successWithValidAcceptHeaderValue() throws MuleRestException {
     validateRequestForAcceptHeader("application/json");
+  }
+
+  @Test
+  public void successWithValidHeaderNameWithCamelCaseNamesInRAML() throws MuleRestException {
+    MultiMap<String, String> headers = new MultiMap<>();
+    headers.put("camelcasearray", "arrayValue");
+    headers.put("camelcasestring", "stringValue");
+    headers.put("smallcasearray", "arrayValue");
+    headers.put("smallcasestring", "stringValue");
+    MultiMap<String, String> validatedHeaders = validateRequestForArrayTypeHeader(headers).getAttributes().getHeaders();
+    assertEquals(validatedHeaders.size(), 4);
+    assertTrue(validatedHeaders.containsKey("camelcasearray"));
+    assertTrue(validatedHeaders.containsKey("camelcasestring"));
+    assertTrue(validatedHeaders.containsKey("smallcasearray"));
+    assertTrue(validatedHeaders.containsKey("smallcasestring"));
+  }
+
+
+  private ValidRequest validateRequestForArrayTypeHeader(MultiMap<String, String> headers) throws MuleRestException {
+
+    return testRestRequestValidatorBuilder
+        .withApiLocation("unit/validation/header-types-api.raml")
+        .withRelativePath("/headerTypes")
+        .withMethod("GET")
+        .withHeaders(headers)
+        .withBody((InputStream) makePayloadRepeatable(toInputStream("{\"message\":\"All Ok\"}", Charset.defaultCharset())))
+        .build()
+        .validateRequest();
   }
 }

--- a/src/test/resources/unit/validation/header-types-api.raml
+++ b/src/test/resources/unit/validation/header-types-api.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0
+title: Header Types Validation Test API
+
+/headerTypes:
+  get:
+    headers:
+      camelCaseArray:
+        type: array
+        required: false
+      smallcasearray:
+        type: array
+        required: false
+      camelCaseString:
+        type: string
+        required: false
+      smallcasestring:
+        type: string
+        required: false


### PR DESCRIPTION
Customer noticed headers of type array changed name of the attribute from small cases to camelcase. It is linked the associated header in the RAML where the name is defined in camelCase (by the customer).
As I understand, the headers are case-insensitive and it shouldn't have mattered, but looks like if we subsequently try to access this header in following components, the case matters.
Eg: if 'targetCode' is the header name defined in the RAML, APIKIT changes incomingHeader 'targetcode' to 'targetCode' and is inaccessible using `attributes.headers.targetcode`

 replacing  `copyIncomingHeaders.put(headerName, values)` to `copyIncomingHeaders.put(headerName.toLowerCase(), values)` can help resolve this as all incoming headers received via mule extensions are lowercase.
 
 WI: [W-16328046](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001xPvdPYAS/view)