### PR TITLE
W-16306395 : Filter RoutingTable to avoid patterns with no actions

### DIFF
--- a/src/main/java/org/mule/module/apikit/Router.java
+++ b/src/main/java/org/mule/module/apikit/Router.java
@@ -19,7 +19,6 @@ import org.mule.module.apikit.api.exception.MuleRestException;
 import org.mule.module.apikit.api.spi.AbstractRouter;
 import org.mule.module.apikit.api.spi.RouterService;
 import org.mule.module.apikit.api.spi.RouterServiceV2;
-import org.mule.module.apikit.api.uri.ResolvedVariables;
 import org.mule.module.apikit.api.uri.URIPattern;
 import org.mule.module.apikit.api.uri.URIResolver;
 import org.mule.module.apikit.api.validation.ValidRequest;

--- a/src/main/java/org/mule/module/apikit/api/RoutingTable.java
+++ b/src/main/java/org/mule/module/apikit/api/RoutingTable.java
@@ -26,11 +26,10 @@ public class RoutingTable {
   private void buildRoutingTable(Map<String, Resource> resources, String version) {
 
     for (Resource resource : resources.values()) {
-
-      String uri = resource.getResolvedUri(version);
-
-      routingTable.put(new URIPattern(uri), resource);
-
+      if (!resource.getActions().isEmpty()) {
+        String uri = resource.getResolvedUri(version);
+        routingTable.put(new URIPattern(uri), resource);
+      }
       if (resource.getResources() != null) {
         buildRoutingTable(resource.getResources(), version);
       }

--- a/src/test/java/org/mule/module/apikit/validation/MethodNotAllowedTestCase.java
+++ b/src/test/java/org/mule/module/apikit/validation/MethodNotAllowedTestCase.java
@@ -7,10 +7,15 @@
 package org.mule.module.apikit.validation;
 
 import org.junit.Test;
+import org.mule.module.apikit.api.RoutingTable;
 import org.mule.module.apikit.api.exception.MethodNotAllowedException;
 import org.mule.module.apikit.api.exception.MuleRestException;
+import org.mule.module.apikit.api.uri.URIPattern;
 
+import static org.junit.Assert.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class MethodNotAllowedTestCase extends AbstractRequestValidatorTestCase {
 
@@ -42,5 +47,19 @@ public class MethodNotAllowedTestCase extends AbstractRequestValidatorTestCase {
         .withMethod("PUT")
         .build()
         .validateRequest();
+  }
+
+  @Test
+  public void validRoutingTableTest() {
+    RoutingTable routingTable = testRestRequestValidatorBuilder
+        .withApiLocation("unit/validation/api-resources.raml")
+        .withRelativePath("/test/something")
+        .withMethod("GET")
+        .build()
+        .getRoutingTable();
+
+    assertNotNull(routingTable);
+    assertEquals(2, routingTable.keySet().size());
+    assertTrue(routingTable.keySet().contains(new URIPattern("/test/{resourceZ}")));
   }
 }

--- a/src/test/java/org/mule/module/apikit/validation/TestRestRequestValidator.java
+++ b/src/test/java/org/mule/module/apikit/validation/TestRestRequestValidator.java
@@ -111,4 +111,9 @@ public class TestRestRequestValidator {
   public OptionalLong getRequestBodyLength() {
     return body instanceof TypedValue ? ((TypedValue) body).getByteLength() : OptionalLong.empty();
   }
+
+  public RoutingTable getRoutingTable() {
+    return (apiReference != null && parser != null) ?
+            new RoutingTable(new ParserService().parse(apiReference, parser).get()) : null;
+  }
 }


### PR DESCRIPTION
Pattern Matched to the URL do not get picked correctly sometimes.

 If there is duplicate matched pattern present, we currently don't control on what pattern is picked

In this example

/test:
  /{resourceB}:
    /resourceC:
      put:
  /{resourceZ}:
    get:

test/123 uri may resolve to either test/{resourceB} pattern or test/{resourceZ} pattern, if the former gets picked, user will see a 405


To fix this, this change filters out any URI patterns with no actions (such as /test/{resourceB}) from the routing table.


Investigation: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001wTP6TYAW/view