### PR TITLE
@W-16189110 - Add timeout for regex validation

### DIFF
--- a/src/main/java/org/mule/module/apikit/validation/body/schema/v2/RestSchemaV2Validator.java
+++ b/src/main/java/org/mule/module/apikit/validation/body/schema/v2/RestSchemaV2Validator.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.concurrent.*;
 
 import static java.util.stream.Collectors.joining;
 
@@ -27,9 +28,20 @@ public class RestSchemaV2Validator implements IRestSchemaValidatorStrategy {
   }
 
   public void validate(String payload) throws BadRequestException {
-    final List<ApiValidationResult> validationResults = mimeType.validate(payload);
-    if (!validationResults.isEmpty()) {
-      throw new BadRequestException(buildLogMessage(validationResults));
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<List<ApiValidationResult>> future = executor.submit(() -> mimeType.validate(payload));
+
+    try {
+      final List<ApiValidationResult> validationResults = future.get(2, TimeUnit.SECONDS);
+      if (!validationResults.isEmpty()) {
+        throw new BadRequestException(buildLogMessage(validationResults));
+      }
+    } catch (TimeoutException e) {
+      throw new BadRequestException("Validation timed out after 2 seconds");
+    } catch (InterruptedException | ExecutionException e) {
+      throw new BadRequestException("Error during validation: " + e.getMessage());
+    } finally {
+      executor.shutdownNow();
     }
   }
 

--- a/src/test/munit/body/validation/schema/with-regex-schema-server.xml
+++ b/src/test/munit/body/validation/schema/with-regex-schema-server.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mule xmlns="http://www.mulesoft.org/schema/mule/core"
+      xmlns:apikit="http://www.mulesoft.org/schema/mule/mule-apikit"
+      xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd
+      http://www.mulesoft.org/schema/mule/mule-apikit http://www.mulesoft.org/schema/mule/mule-apikit/current/mule-apikit.xsd
+      http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd">
+
+
+    <apikit:config name="with-regex-schema-config" api="${api.location}"
+                   outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus"
+                   parser="${parser.type}"/>
+
+    <flow name="with-regex-schema-main">
+        <http:listener config-ref="http-listener-simple" path="/with-regex-schema/*">
+            <http:response statusCode="#[vars.httpStatus default 200]">
+                <http:headers>#[vars.outboundHeaders default {}]</http:headers>
+            </http:response>
+            <http:error-response statusCode="#[vars.httpStatus default 500]">
+                <http:headers>#[vars.outboundHeaders default {}]</http:headers>
+            </http:error-response>
+        </http:listener>
+        <apikit:router config-ref="with-regex-schema-config"/>
+        <error-handler ref="global-server-error-handler"/>
+    </flow>
+
+    <flow name="post:\ordercreate:with-regex-schema-config">
+        <set-payload value="123456789"/>
+    </flow>
+
+</mule>

--- a/src/test/munit/body/validation/schema/with-regex-schema-test-suite.xml
+++ b/src/test/munit/body/validation/schema/with-regex-schema-test-suite.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<mule xmlns:http="http://www.mulesoft.org/schema/mule/http"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xmlns:munit="http://www.mulesoft.org/schema/mule/munit"
+      xmlns:munit-tools="http://www.mulesoft.org/schema/mule/munit-tools"
+      xmlns="http://www.mulesoft.org/schema/mule/core"
+      xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+		http://www.mulesoft.org/schema/mule/munit http://www.mulesoft.org/schema/mule/munit/current/mule-munit.xsd
+		http://www.mulesoft.org/schema/mule/munit-tools  http://www.mulesoft.org/schema/mule/munit-tools/current/mule-munit-tools.xsd
+        http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd">
+
+    <munit:config name="with-schema-test-suite">
+        <munit:parameterizations>
+            <munit:parameterization name="AMF-OAS30">
+                <munit:parameters>
+                    <munit:parameter propertyName="api.version" value="OAS30"/>
+                    <munit:parameter propertyName="parser.type" value="AMF"/>
+                    <munit:parameter propertyName="api.location" value="munit/body/schema/oas-30-with-regex-schema.json"/>
+                </munit:parameters>
+            </munit:parameterization>
+        </munit:parameterizations>
+    </munit:config>
+
+    <munit:test name="post-valid-json">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="with-regex-schema-main"/>
+            <munit:enable-flow-source value="post:\ordercreate:with-regex-schema-config"/>
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <http:request method="POST" config-ref="http-requester-simple" path="/with-regex-schema/ordercreate">
+                <http:body>#['{"MagentoSalesOrderCreate":{"OrderHeader":{"OrderByName":"John Doe","Email":"john.doe@example.com","ReceiverName":"ABC Company"}}}']</http:body>
+                <http:headers>#[{"Content-Type": "application/json"}]</http:headers>
+                <http:response-validator>
+                    <http:success-status-code-validator values="1..500"/>
+                </http:response-validator>
+            </http:request>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(201)]"/>
+            <munit-tools:assert-that expression="#[output text/plain --- payload]" is="#[MunitTools::equalTo('123456789')]"/>
+        </munit:validation>
+    </munit:test>
+
+    <munit:test name="post-invalid-json">
+        <munit:enable-flow-sources>
+            <munit:enable-flow-source value="with-regex-schema-main"/>
+            <munit:enable-flow-source value="post:\ordercreate:with-regex-schema-config"/>
+        </munit:enable-flow-sources>
+        <munit:execution>
+            <http:request method="POST" config-ref="http-requester-simple" path="/with-regex-schema/ordercreate">
+                <http:body>#['{"MagentoSalesOrderCreate":{"OrderHeader":{"OrderByName":"Tom Günther","Email":"tom.guenther@fischerschweiger.de","ReceiverName":"Rothenhuber Land- und Baumaschinentechnik Tom Günther 0160-2833173"}}}']</http:body>
+                <http:headers>#[{"Content-Type": "application/json"}]</http:headers>
+                <http:response-validator>
+                    <http:success-status-code-validator values="1..500"/>
+                </http:response-validator>
+            </http:request>
+        </munit:execution>
+        <munit:validation>
+            <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(400)]"/>
+        </munit:validation>
+    </munit:test>
+
+</mule>


### PR DESCRIPTION
**Issue:**
WI: [W-16189110](https://gus.lightning.force.com/a07EE00001wC7UCYA0)
The APIKit Router occasionally freezes when accented characters are included in the payload. This issue arises when the API specification includes regex parsing.

**Example:**

For instance, if the payload contains a string like `Tom Günther` and the API specification defines a regex pattern such as `([a-zA-Z0-9 -_.@&$]*)+$`, the application freezes upon sending the API request. The expected behavior in such cases is to throw a `BadRequestException`, since the accented character (ü) is not covered by the specified regex pattern.

**Fix:**
To resolve this issue, a timeout mechanism has been implemented for the regex validation logic. If the validation does not complete within 2 seconds, a `BadRequestException` is thrown to ensure that the application does not hang indefinitely.