### PR TITLE
@W-16552229 - Update scope of plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -589,32 +589,36 @@
                     </execution>
                 </executions>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>com.mycila</groupId>-->
-<!--                <artifactId>license-maven-plugin</artifactId>-->
-<!--                <version>2.11</version>-->
-<!--                <configuration>-->
-<!--                    <header>com/mycila/maven/plugin/license/templates/CPAL.txt</header>-->
-<!--                    <properties>-->
-<!--                        <owner>MuleSoft, Inc</owner>-->
-<!--                        <project.url>http://www.mulesoft.com</project.url>-->
-<!--                    </properties>-->
-<!--                    <includes>-->
-<!--                        <include>**/*.java</include>-->
-<!--                    </includes>-->
-<!--                    <mapping>-->
-<!--                        <java>SLASHSTAR_STYLE</java>-->
-<!--                    </mapping>-->
-<!--                </configuration>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <phase>compile</phase>-->
-<!--                        <goals>-->
-<!--                            <goal>check</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.11</version>
+                <configuration>
+                    <header>com/mycila/maven/plugin/license/templates/CPAL.txt</header>
+                    <properties>
+                        <owner>MuleSoft, Inc</owner>
+                        <project.url>http://www.mulesoft.com</project.url>
+                    </properties>
+                    <includes>
+                        <include>src/main/java/**/*.java</include>
+                        <include>src/test/java/**/*.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>src/test/java/Fips*.java</exclude>
+                    </excludes>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -639,6 +643,13 @@
                     <executionRoot>true</executionRoot>
                     <encoding>UTF-8</encoding>
                     <lineEnding>LF</lineEnding>
+                    <includes>
+                        <include>src/main/java/**/*.java</include>
+                        <include>src/test/java/**/*.java</include>
+                    </includes>
+                    <excludes>
+                        <exclude>src/test/java/Fips*.java</exclude>
+                    </excludes>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -589,32 +589,32 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>2.11</version>
-                <configuration>
-                    <header>com/mycila/maven/plugin/license/templates/CPAL.txt</header>
-                    <properties>
-                        <owner>MuleSoft, Inc</owner>
-                        <project.url>http://www.mulesoft.com</project.url>
-                    </properties>
-                    <includes>
-                        <include>**/*.java</include>
-                    </includes>
-                    <mapping>
-                        <java>SLASHSTAR_STYLE</java>
-                    </mapping>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>com.mycila</groupId>-->
+<!--                <artifactId>license-maven-plugin</artifactId>-->
+<!--                <version>2.11</version>-->
+<!--                <configuration>-->
+<!--                    <header>com/mycila/maven/plugin/license/templates/CPAL.txt</header>-->
+<!--                    <properties>-->
+<!--                        <owner>MuleSoft, Inc</owner>-->
+<!--                        <project.url>http://www.mulesoft.com</project.url>-->
+<!--                    </properties>-->
+<!--                    <includes>-->
+<!--                        <include>**/*.java</include>-->
+<!--                    </includes>-->
+<!--                    <mapping>-->
+<!--                        <java>SLASHSTAR_STYLE</java>-->
+<!--                    </mapping>-->
+<!--                </configuration>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <phase>compile</phase>-->
+<!--                        <goals>-->
+<!--                            <goal>check</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
**Issue:**
The module was failing the FIPS pipeline because the following plugins were not limited to the current module's files. As a result, they were applied to all files, including those introduced by the FIPS pipeline. Since we don't have ownership over these external files, the license and format checks were failing on them:
- `com.mycila:license-maven-plugin`
- `net.revelc.code.formatter:formatter-maven-plugin`

**Fix:**
The scope of these plugins has been restricted to include only the files within the module. FIPS-related files added during testing have been excluded to prevent unnecessary validation failures.