### PR TITLE
Bump commons-io:commons-io from 2.8.0 to 2.14.0 (#803)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <maven.enforcer.plugin.version>1.4.1</maven.enforcer.plugin.version>
         <jar.plugin.version>3.0.2</jar.plugin.version>
         <commons.codec.version>1.15</commons.codec.version>
-        <commons.io.version>2.8.0</commons.io.version>
+        <commons.io.version>2.14.0</commons.io.version>
         <log4j.version>2.17.1</log4j.version>
 
         <!-- PARSERS -->


### PR DESCRIPTION
Bumps commons-io:commons-io from 2.8.0 to 2.14.0.
Cherry pick #803 

---
updated-dependencies:
- dependency-name: commons-io:commons-io dependency-type: direct:production ...