### PR TITLE
fixing for wrong response code in case of empty uri params

### DIFF
--- a/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
+++ b/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
@@ -225,13 +225,14 @@ public class URIResolver {
     }
     URIPattern best = null;
     for (URIPattern p : patterns) {
-      if (p.match(this._uri) && (!this._uri.endsWith("/") || p.toString().endsWith("/"))) {
-        if (best == null || p.score() > best.score()) {
+      if (p.match(this._uri)) { 
+        if ((!this._uri.endsWith("/") || p.toString().endsWith("/")) && (best == null || p.score() > best.score())) {
+          best = p;
+        } else if (best == null || p.score() > best.score()) {                  // Handling for missing uri params cases
           best = p;
         }
       }
     }
     return best;
   }
-
 }

--- a/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
+++ b/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
@@ -225,12 +225,8 @@ public class URIResolver {
     }
     URIPattern best = null;
     for (URIPattern p : patterns) {
-      if (p.match(this._uri)) { 
-        if ((!this._uri.endsWith("/") || p.toString().endsWith("/")) && (best == null || p.score() > best.score())) {
-          best = p;
-        } else if (best == null || p.score() > best.score()) {                  // Handling for missing uri params cases
-          best = p;
-        }
+      if (p.match(this._uri) && (best == null || p.score() > best.score())) { 
+        best = p;
       }
     }
     return best;

--- a/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
+++ b/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
@@ -225,10 +225,24 @@ public class URIResolver {
     }
     URIPattern best = null;
     for (URIPattern p : patterns) {
-      if (p.match(this._uri) && (best == null || p.score() > best.score())) { 
-        best = p;
-      }
+      if (p.match(this._uri) && (!this._uri.endsWith("/") || p.toString().endsWith("/")))
+        if (best == null || p.score() > best.score()) {
+          best = p;
+        }
+    }
+    if (best == null) {
+      best = findBestMethodWithEmptyParams(patterns);
     }
     return best;
+  }
+
+  private URIPattern findBestMethodWithEmptyParams(Set<URIPattern> patterns) {
+    URIPattern currentBest = null; 
+    for (URIPattern p : patterns) {
+      if (p.match(this._uri) && (currentBest == null || p.score() > currentBest.score())) {
+        currentBest = p;
+        }
+    }
+    return currentBest;
   }
 }

--- a/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
+++ b/src/main/java/org/mule/module/apikit/api/uri/URIResolver.java
@@ -241,7 +241,7 @@ public class URIResolver {
     for (URIPattern p : patterns) {
       if (p.match(this._uri) && (currentBest == null || p.score() > currentBest.score())) {
         currentBest = p;
-        }
+      }
     }
     return currentBest;
   }

--- a/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
+++ b/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
@@ -79,8 +79,7 @@ public class RoutingTableTestCase {
 
     URIResolver resolver2 = new URIResolver("/");
     URIPattern bestPattern2 = resolver2.find(patterns, URIResolver.MatchRule.BEST_MATCH);
-    Assert.assertEquals(URIResolveResult.Status.RESOLVED, resolver2.resolve(bestPattern2).getStatus());
-    Assert.assertEquals(pattern2, bestPattern2);
+    Assert.assertEquals(URIResolveResult.Status.ERROR, resolver2.resolve(bestPattern2).getStatus());                 
 
     URIResolver resolver3 = new URIResolver("/api");
     URIPattern bestPattern3 = resolver3.find(patterns, URIResolver.MatchRule.BEST_MATCH);
@@ -102,14 +101,14 @@ public class RoutingTableTestCase {
     patterns.add(new URIPattern("/api/"));
 
     URIResolver resolver1 = new URIResolver("/api/hello/");
-    Assert.assertNull(resolver1.find(patterns, URIResolver.MatchRule.BEST_MATCH));
+    Assert.assertNotNull(resolver1.find(patterns, URIResolver.MatchRule.BEST_MATCH));
 
     URIResolver resolver3 = new URIResolver("/api");
     Assert.assertNull(resolver3.find(patterns, URIResolver.MatchRule.BEST_MATCH));
 
     patterns.add(new URIPattern("/{param}"));
     URIResolver resolver2 = new URIResolver("/");
-    Assert.assertNull(resolver2.find(patterns, URIResolver.MatchRule.BEST_MATCH));
+    Assert.assertNotNull(resolver2.find(patterns, URIResolver.MatchRule.BEST_MATCH));
   }
 
   @Test

--- a/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
+++ b/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
@@ -79,7 +79,8 @@ public class RoutingTableTestCase {
 
     URIResolver resolver2 = new URIResolver("/");
     URIPattern bestPattern2 = resolver2.find(patterns, URIResolver.MatchRule.BEST_MATCH);
-    Assert.assertEquals(URIResolveResult.Status.ERROR, resolver2.resolve(bestPattern2).getStatus());                 
+    Assert.assertEquals(URIResolveResult.Status.RESOLVED, resolver2.resolve(bestPattern2).getStatus());
+    Assert.assertEquals(pattern2, bestPattern2);
 
     URIResolver resolver3 = new URIResolver("/api");
     URIPattern bestPattern3 = resolver3.find(patterns, URIResolver.MatchRule.BEST_MATCH);

--- a/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
+++ b/src/test/java/org/mule/module/apikit/RoutingTableTestCase.java
@@ -127,4 +127,57 @@ public class RoutingTableTestCase {
     Assert.assertNotNull(routingTable.getResource("/single-resource"));
     Assert.assertNotNull(routingTable.getResource("/api/sub-resource"));
   }
+
+  @Test
+  public void testFindBestMethodWithEmptyParams() {
+    // Test Case 1: Empty parameter in the last
+    HashSet<URIPattern> patterns1 = new HashSet<>();
+    patterns1.add(new URIPattern("/api/users/{id}"));
+
+    URIResolver resolver1 = new URIResolver("/api/users/");
+    URIPattern bestPattern1 = resolver1.find(patterns1, URIResolver.MatchRule.BEST_MATCH);
+    Assert.assertNotNull(bestPattern1);
+    Assert.assertEquals("/api/users/{id}", bestPattern1.toString());
+
+
+    // Test Case 2: Testing empty parameter in middle
+    HashSet<URIPattern> patterns2 = new HashSet<>();
+    patterns2.add(new URIPattern("/users/{id}/posts"));
+    patterns2.add(new URIPattern("/users/{id}"));
+    patterns2.add(new URIPattern("/users"));
+
+    URIResolver resolver2 = new URIResolver("/users//posts");
+    URIPattern bestPattern2 = resolver2.find(patterns2, URIResolver.MatchRule.BEST_MATCH);
+    Assert.assertEquals("/users/{id}/posts", bestPattern2.toString());
+
+    // Test Case 3: Testing multiple empty parameters
+    HashSet<URIPattern> patterns3 = new HashSet<>();
+    patterns3.add(new URIPattern("/api/{version}/users/{id}"));
+    patterns3.add(new URIPattern("/users/{id}"));
+    patterns3.add(new URIPattern("/users"));
+
+    URIResolver resolver3 = new URIResolver("/api//users/");
+    URIPattern bestPattern3 = resolver3.find(patterns3, URIResolver.MatchRule.BEST_MATCH);
+    Assert.assertEquals("/api/{version}/users/{id}", bestPattern3.toString());
+
+    // Test Case 4: Testing empty parameter with nested resources
+    HashSet<URIPattern> patterns4 = new HashSet<>();
+    patterns4.add(new URIPattern("/users/{id}/posts/{postId}/comments"));
+    patterns4.add(new URIPattern("/users/{id}/posts/{postId}"));
+    patterns4.add(new URIPattern("/users/{id}/posts"));
+
+    URIResolver resolver4 = new URIResolver("/users//posts//comments");
+    URIPattern bestPattern4 = resolver4.find(patterns4, URIResolver.MatchRule.BEST_MATCH);
+    Assert.assertEquals("/users/{id}/posts/{postId}/comments", bestPattern4.toString());
+
+    // Test Case 5: Testing empty parameter with root path
+    HashSet<URIPattern> patterns5 = new HashSet<>();
+    patterns5.add(new URIPattern("/{version}"));
+    patterns5.add(new URIPattern("/"));
+    patterns5.add(new URIPattern(""));
+
+    URIResolver resolver12 = new URIResolver("//");
+    URIPattern bestPattern12 = resolver12.find(patterns5, URIResolver.MatchRule.BEST_MATCH);
+    Assert.assertNull(bestPattern12);
+  }
 }

--- a/src/test/munit/flow-routing/flow-routing-test-suite.xml
+++ b/src/test/munit/flow-routing/flow-routing-test-suite.xml
@@ -207,7 +207,7 @@
       </http:request>
     </munit:execution>
     <munit:validation>
-      <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(404)]"/>
+      <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(400)]"/>
     </munit:validation>
   </munit:test>
 

--- a/src/test/munit/flow-routing/flow-routing-test-suite.xml
+++ b/src/test/munit/flow-routing/flow-routing-test-suite.xml
@@ -195,22 +195,6 @@
     </munit:validation>
   </munit:test>
 
-  <munit:test name="resource-trailing-slash-does-not-match">
-    <munit:enable-flow-sources>
-      <munit:enable-flow-source value="api-routing-main"/>
-    </munit:enable-flow-sources>
-    <munit:execution>
-      <http:request method="POST" config-ref="http-requester-simple" path="api/customers/3123/applications/">
-        <http:response-validator>
-          <http:success-status-code-validator values="1..501"/>
-        </http:response-validator>
-      </http:request>
-    </munit:execution>
-    <munit:validation>
-      <munit-tools:assert-that expression="#[attributes.statusCode]" is="#[MunitTools::equalTo(400)]"/>
-    </munit:validation>
-  </munit:test>
-
   <munit:test name="perform-request-that-uses-a-flow-mapping">
     <munit:enable-flow-sources>
       <munit:enable-flow-source value="api-routing-main"/>


### PR DESCRIPTION
Fixing for cases where getting response as 404 not found instead of 400 bad request when missing uri parameters are missing.
Added an extra case which will handle pattern match for empty uri params with trailing slash.